### PR TITLE
Unpublish fragment

### DIFF
--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/unpublish/UnpublishConfirmFragment.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/unpublish/UnpublishConfirmFragment.java
@@ -5,22 +5,19 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import android.view.LayoutInflater;
-import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 
-import java.util.Calendar;
 
-public class UnpublishFragment1_Confirm extends DialogFragment {
+public class UnpublishConfirmFragment extends DialogFragment {
 
 
     private OnFragmentInteractionListener listener;
 
     public interface OnFragmentInteractionListener {
-        void onOkPressed();
+        void onUnpublishPressed();
     }
 
     @Override
@@ -45,16 +42,14 @@ public class UnpublishFragment1_Confirm extends DialogFragment {
         return builder
                 .setTitle("Are you sure you want to unpublish this experiment?")
                 .setNegativeButton("CANCEL", null)
-                .setPositiveButton("YES", new DialogInterface.OnClickListener() {
+                .setPositiveButton("UNPUBLISH", new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
 
-                        listener.onOkPressed();
-
+                        listener.onUnpublishPressed();
 
                     }}).create();
 
     }
-
 
 }

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/unpublish/UnpublishFragment1_Confirm.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/unpublish/UnpublishFragment1_Confirm.java
@@ -1,0 +1,60 @@
+package com.faanggang.wisetrack.unpublish;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import java.util.Calendar;
+
+public class UnpublishFragment1_Confirm extends DialogFragment {
+
+
+    private OnFragmentInteractionListener listener;
+
+    public interface OnFragmentInteractionListener {
+        void onOkPressed();
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (context instanceof OnFragmentInteractionListener){
+            listener = (OnFragmentInteractionListener) context;
+        } else {
+            throw new RuntimeException(context.toString()
+                    + " must implement OnFragmentInteractionListener");
+        }
+    }
+
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+
+        return builder
+                .setTitle("Are you sure you want to unpublish this experiment?")
+                .setNegativeButton("CANCEL", null)
+                .setPositiveButton("YES", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+
+                        listener.onOkPressed();
+
+
+                    }}).create();
+
+    }
+
+
+}


### PR DESCRIPTION
Created a confirmation dialog to unpublish the experiment:
- Updates the database "open" field to FALSE
- Updates the keywords: removes "OPEN" keyword and adds "CLOSED"

Todo:
- Add a success and error dialog for the user to see. Currently, a message is displayed in the log.
- Get rid of "unpublish" option if the experiment is already closed