### PR TITLE
Refractor: Change `unpublish` implementations to `end experiment`

### DIFF
--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/experiment/EndExperimentConfirmFragment.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/experiment/EndExperimentConfirmFragment.java
@@ -1,4 +1,4 @@
-package com.faanggang.wisetrack.unpublish;
+package com.faanggang.wisetrack.experiment;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -11,13 +11,13 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 
 
-public class UnpublishConfirmFragment extends DialogFragment {
+public class EndExperimentConfirmFragment extends DialogFragment {
 
 
     private OnFragmentInteractionListener listener;
 
     public interface OnFragmentInteractionListener {
-        void onUnpublishPressed();
+        void onEndExperimentOk();
     }
 
     @Override
@@ -40,13 +40,13 @@ public class UnpublishConfirmFragment extends DialogFragment {
         AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
 
         return builder
-                .setTitle("Are you sure you want to unpublish this experiment?")
+                .setTitle("Are you sure you want to end this experiment?")
                 .setNegativeButton("CANCEL", null)
-                .setPositiveButton("UNPUBLISH", new DialogInterface.OnClickListener() {
+                .setPositiveButton("YES", new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
 
-                        listener.onUnpublishPressed();
+                        listener.onEndExperimentOk();
 
                     }}).create();
 

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/experiment/ViewExperimentActivity.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/experiment/ViewExperimentActivity.java
@@ -9,7 +9,6 @@ import com.faanggang.wisetrack.executeTrial.ExecuteCountActivity;
 import com.faanggang.wisetrack.executeTrial.ExecuteMeasurementActivity;
 import com.faanggang.wisetrack.WiseTrackApplication;
 import com.faanggang.wisetrack.comment.ViewAllCommentActivity;
-import com.faanggang.wisetrack.unpublish.UnpublishConfirmFragment;
 import com.faanggang.wisetrack.user.UserManager;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -31,7 +30,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 public class ViewExperimentActivity extends AppCompatActivity
-    implements UnpublishConfirmFragment.OnFragmentInteractionListener{
+    implements EndExperimentConfirmFragment.OnFragmentInteractionListener{
     private FirebaseFirestore db = FirebaseFirestore.getInstance();
     private TextView expNameView;
     private TextView expDescriptionView;
@@ -147,13 +146,13 @@ public class ViewExperimentActivity extends AppCompatActivity
                 return true;  // item clicked return true
             case R.id.unpublish_option:
                 Toast.makeText(this, "Unpublish option selected", Toast.LENGTH_SHORT).show();
-
-                UnpublishConfirmFragment frag = new UnpublishConfirmFragment();
-                frag.show(getSupportFragmentManager(), "UNPUBLISH_EXPERIMENT");
-
                 return true;
             case R.id.end_experiment_option:
                 Toast.makeText(this, "End experiment option selected", Toast.LENGTH_SHORT).show();
+
+                EndExperimentConfirmFragment frag = new EndExperimentConfirmFragment();
+                frag.show(getSupportFragmentManager(), "END_EXPERIMENT");
+
                 return true;
             case R.id.results_option:
                 Toast.makeText(this, "View experiment results selected", Toast.LENGTH_SHORT).show();
@@ -194,7 +193,7 @@ public class ViewExperimentActivity extends AppCompatActivity
 
 
     @Override
-    public void onUnpublishPressed(){
+    public void onEndExperimentOk(){
         DocumentReference experiment = db.collection("Experiments").document(expID);
 
         experiment
@@ -202,13 +201,13 @@ public class ViewExperimentActivity extends AppCompatActivity
                 .addOnSuccessListener(new OnSuccessListener<Void>() {
                     @Override
                     public void onSuccess(Void aVoid) {
-                        Log.d("UNPUBLISH", "Experiment " + expID + " successfully updated!");
+                        Log.d("END_EXPERIMENT", "Experiment " + expID + " successfully updated!");
                     }
                 })
                 .addOnFailureListener(new OnFailureListener() {
                     @Override
                     public void onFailure(@NonNull Exception e) {
-                        Log.w("UNPUBLISH", "Error updating document", e);
+                        Log.w("END_EXPERIMENT", "Error updating document", e);
 
                         // ADD AN ERROR FRAGMENT HERE
                     }


### PR DESCRIPTION
Implementations for `unpublish` were incorrect and were actually for `end experiment`. Renamed files and adjusted the button clicks to fit `End Experiment` option instead