### PR TITLE
render trials that have geolocation

### DIFF
--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/controllers/ExecuteTrialController.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/controllers/ExecuteTrialController.java
@@ -12,6 +12,7 @@ import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.GeoPoint;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,7 +42,11 @@ public class ExecuteTrialController {
     public Map createTrialDocument(CountTrial trial) {
         Map<String, Object> data = new HashMap<>();
         data.put("result", trial.getCount());
-        data.put("geolocation", trial.getTrialGeolocation());
+        if (trial.getTrialGeolocation() == null) {
+            data.put("geolocation", null);
+        } else {
+            data.put("geolocation", new GeoPoint(trial.getTrialGeolocation().getLatitude(), trial.getTrialGeolocation().getLongitude()));
+        }
         data.put("date", trial.getDatetime());
         data.put("conductor id", trial.getExperimenterID());
         //data.put("trial id", trial.getTrialID());
@@ -56,7 +61,11 @@ public class ExecuteTrialController {
     public Map createTrialDocument(BinomialTrial trial) {
         Map<String, Object> data = new HashMap<>();
         data.put("result", trial.getTrialResult());
-        data.put("geolocation", trial.getTrialGeolocation());
+        if (trial.getTrialGeolocation() == null) {
+            data.put("geolocation", null);
+        } else {
+            data.put("geolocation", new GeoPoint(trial.getTrialGeolocation().getLatitude(), trial.getTrialGeolocation().getLongitude()));
+        }
         data.put("date", trial.getDatetime());
         data.put("conductor id", trial.getExperimenterID());
         //data.put("trial id", trial.getTrialID());
@@ -71,7 +80,11 @@ public class ExecuteTrialController {
     public Map createTrialDocument(MeasurementTrial trial) {
         Map<String, Object> data = new HashMap<>();
         data.put("result", trial.getMeasurement());
-        data.put("geolocation", trial.getTrialGeolocation());
+        if (trial.getTrialGeolocation() == null) {
+            data.put("geolocation", null);
+        } else {
+            data.put("geolocation", new GeoPoint(trial.getTrialGeolocation().getLatitude(), trial.getTrialGeolocation().getLongitude()));
+        }
         data.put("date", trial.getDatetime());
         data.put("conductor id", trial.getExperimenterID());
         //data.put("trial id", trial.getTrialID());

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/controllers/TrialFetchManager.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/controllers/TrialFetchManager.java
@@ -1,5 +1,6 @@
 package com.faanggang.wisetrack.controllers;
 
+import android.location.Location;
 import android.util.Log;
 
 import com.faanggang.wisetrack.model.executeTrial.BinomialTrial;
@@ -10,6 +11,7 @@ import com.faanggang.wisetrack.model.experiment.Experiment;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.GeoPoint;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -49,11 +51,17 @@ public class TrialFetchManager {
                                     if (task1.isSuccessful()) {
                                         ArrayList<Trial> trials = new ArrayList<>();
                                         for (DocumentSnapshot docSnapshot : task1.getResult().getDocuments()) {
-                                            Log.w("TRIALS", docSnapshot.getString("result"));
+                                            GeoPoint geoPoint = docSnapshot.getGeoPoint("geolocation");
+                                            Location location = null;
+                                            if (geoPoint != null) {
+                                                location = new Location("");
+                                                location.setLatitude(geoPoint.getLatitude());
+                                                location.setLongitude(geoPoint.getLongitude());
+                                            }
                                             trials.add(createTrial(
                                                     trialType,
                                                     docSnapshot.getLong("result"),
-                                                    docSnapshot.getString("geolocation"),
+                                                    location,
                                                     docSnapshot.getString("conductor id"),
                                                     docSnapshot.getDate("date"))
                                             );
@@ -65,7 +73,7 @@ public class TrialFetchManager {
                 });
     }
 
-    public Trial createTrial(int trialType, float trialResult, String trialGeolocation, String conductorID, Date date) {
+    public Trial createTrial(int trialType, float trialResult, Location trialGeolocation, String conductorID, Date date) {
         Trial trial;
         if ((trialType == 0)||(trialType == 2)) {  // count and NNIC type trials
             trial = new CountTrial((int)trialResult, trialGeolocation, conductorID, date);

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/controllers/TrialFetchManager.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/controllers/TrialFetchManager.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class TrialFetchManager {
     private TrialFetcher fetcher;
@@ -51,7 +52,11 @@ public class TrialFetchManager {
                                     if (task1.isSuccessful()) {
                                         ArrayList<Trial> trials = new ArrayList<>();
                                         for (DocumentSnapshot docSnapshot : task1.getResult().getDocuments()) {
-                                            GeoPoint geoPoint = docSnapshot.getGeoPoint("geolocation");
+                                            Object locationObj = docSnapshot.get("geolocation");
+                                            if (locationObj instanceof String || locationObj instanceof Map) {
+                                                continue;
+                                            }
+                                            GeoPoint geoPoint = (GeoPoint) locationObj;
                                             Location location = null;
                                             if (geoPoint != null) {
                                                 location = new Location("");

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/model/WiseTrackApplication.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/model/WiseTrackApplication.java
@@ -2,11 +2,13 @@ package com.faanggang.wisetrack.model;
 
 import android.app.Application;
 
+import com.faanggang.wisetrack.model.experiment.Experiment;
 import com.faanggang.wisetrack.model.user.Users;
 
 public class WiseTrackApplication extends Application {
 
     transient private static Users currentUser = null;
+    transient private static Experiment currentExperiment = null;
 
     public static void setCurrentUser(Users user) {
         currentUser = user;

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/model/executeTrial/BinomialTrial.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/model/executeTrial/BinomialTrial.java
@@ -1,5 +1,7 @@
 package com.faanggang.wisetrack.model.executeTrial;
 
+import android.location.Location;
+
 import java.util.Date;
 
 public class BinomialTrial extends Trial{
@@ -11,7 +13,7 @@ public class BinomialTrial extends Trial{
      * @param uID              : user id of the trial conductor
      * @param date
      */
-    public BinomialTrial(int trialResult, String trialGeolocation, String uID, Date date) {
+    public BinomialTrial(int trialResult, Location trialGeolocation, String uID, Date date) {
         super(trialGeolocation, uID, date);
         this.trialResult = trialResult;
     }

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/model/executeTrial/CountTrial.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/model/executeTrial/CountTrial.java
@@ -1,5 +1,7 @@
 package com.faanggang.wisetrack.model.executeTrial;
 
+import android.location.Location;
+
 import java.util.Date;
 
 public class CountTrial extends Trial{
@@ -10,7 +12,7 @@ public class CountTrial extends Trial{
      * @param uID              : user id of the trial conductor
      * @param date
      */
-    public CountTrial(int count, String trialGeolocation, String uID, Date date) {
+    public CountTrial(int count, Location trialGeolocation, String uID, Date date) {
         super(trialGeolocation, uID, date);
         this.count = count;
     }

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/model/executeTrial/MeasurementTrial.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/model/executeTrial/MeasurementTrial.java
@@ -1,5 +1,7 @@
 package com.faanggang.wisetrack.model.executeTrial;
 
+import android.location.Location;
+
 import java.util.Date;
 
 public class MeasurementTrial extends Trial {
@@ -11,7 +13,7 @@ public class MeasurementTrial extends Trial {
      * @param uID              : user id of the trial conductor
      * @param date
      */
-    public MeasurementTrial(float measurement, String trialGeolocation, String uID, Date date) {
+    public MeasurementTrial(float measurement, Location trialGeolocation, String uID, Date date) {
         super(trialGeolocation, uID, date);
         this.measurement = measurement;
     }

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/model/executeTrial/Trial.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/model/executeTrial/Trial.java
@@ -1,9 +1,11 @@
 package com.faanggang.wisetrack.model.executeTrial;
 
+import android.location.Location;
+
 import java.util.Date;
 
 public abstract class Trial {
-    private String trialGeolocation;
+    private Location trialGeolocation;
     private String experimenterID;
     private Date datetime;
     private String trialID;  // trial document ID in firebase
@@ -13,17 +15,17 @@ public abstract class Trial {
      * @param uID: user id of the trial conductor
      * @param date
      */
-    public Trial(String trialGeolocation, String uID, Date date) {
+    public Trial(Location trialGeolocation, String uID, Date date) {
         this.trialGeolocation = trialGeolocation;
         this.experimenterID = uID;
         this.datetime = date;
     }
 
-    public String getTrialGeolocation() {
+    public Location getTrialGeolocation() {
         return trialGeolocation;
     }
 
-    public void setTrialGeolocation(String trialGeolocation) {
+    public void setTrialGeolocation(Location trialGeolocation) {
         this.trialGeolocation = trialGeolocation;
     }
 

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/experiment/ViewExperimentActivity.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/experiment/ViewExperimentActivity.java
@@ -266,6 +266,7 @@ public class ViewExperimentActivity extends AppCompatActivity
                 return true;
             case R.id.geolocations_option:
                 Intent geolocationIntent = new Intent(this, MapActivity.class);
+                geolocationIntent.putExtra("EXP_ID", expID);
                 startActivity(geolocationIntent);
                 return true;
             case R.id.execute_trials_option:
@@ -323,23 +324,25 @@ public class ViewExperimentActivity extends AppCompatActivity
 
 
     private boolean selectExecute() {
+        Intent executeIntent;
+
         if (anotherTrialType == 0 || anotherTrialType == 2) {  // handle both count and non-negative integer count trial
-            Intent executeIntent = new Intent(ViewExperimentActivity.this, ExecuteCountActivity.class);
+            executeIntent = new Intent(ViewExperimentActivity.this, ExecuteCountActivity.class);
             executeIntent.putExtra("EXP_ID", expID);
             executeIntent.putExtra("trialType", anotherTrialType);
-            startActivity(executeIntent);
-            return true;
+
         } else if (anotherTrialType == 1) {  // handle binomial trial
-            Intent executeIntent = new Intent(ViewExperimentActivity.this, ExecuteBinomialActivity.class);
+            executeIntent = new Intent(ViewExperimentActivity.this, ExecuteBinomialActivity.class);
             executeIntent.putExtra("EXP_ID", expID);
-            startActivity(executeIntent);
-            return true;
-        } else if (anotherTrialType == 3) {  // handle measurement trial
-            Intent executeIntent = new Intent(ViewExperimentActivity.this, ExecuteMeasurementActivity.class);
+        } else {  // handle measurement trial ( 3 is only option left )
+            executeIntent = new Intent(ViewExperimentActivity.this, ExecuteMeasurementActivity.class);
             executeIntent.putExtra("EXP_ID", expID);
-            startActivity(executeIntent);
-            return true;
      }
+        if (geolocationRequired) {
+            executeIntent.putExtra("GEOLOCATION", geolocationManager.getLastLocation());
+        }
+
+        startActivity(executeIntent);
         return true;
     }
 

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/map/MapActivity.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/map/MapActivity.java
@@ -48,49 +48,36 @@ public class MapActivity extends AppCompatActivity implements TrialFetchManager.
         firebaseFirestore = FirebaseFirestore.getInstance();
         geolocationManager = GeolocationManager.getInstance(this);
         geolocationManager.setContext(this);
+        TrialFetchManager trialFetchManager = new TrialFetchManager(firebaseFirestore, this);
 
-        Intent intent = getIntent();
-        String experimentId = intent.getStringExtra("EXP_ID");
 
+        Bundle intent = getIntent().getExtras();
+        String experimentId = intent.getString("EXP_ID");
+        trialFetchManager.fetchTrials(experimentId);
 
         map = findViewById(R.id.mapview);
         Configuration.getInstance().setUserAgentValue(this.getPackageName());
 
-        //map.getOverlays().add(this.myLocationNewOverlay);
-        //GeoPoint mL = myLocationNewOverlay.getMyLocation();
         map.getController().setZoom(7.0);
-        if (geolocationManager.getLastLocation() != null) {
-            GeoPoint location = new GeoPoint(geolocationManager.getLastLocation().getLatitude(), geolocationManager.getLastLocation().getLongitude());
-            GeoPoint location2 = new GeoPoint(geolocationManager.getLastLocation().getLatitude() +  10, geolocationManager.getLastLocation().getLongitude() + 10);
-
-            renderLocation(location);
-            Marker currentLocationMarker = new Marker(map);
-            currentLocationMarker.setOnMarkerClickListener((marker, mapView) -> true);
-            Marker currentLocationMarker2 = new Marker(map);
-            currentLocationMarker2.setOnMarkerClickListener((marker, mapView) -> true);
-
-            currentLocationMarker.setPosition(location);
-            currentLocationMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-            map.getOverlays().add(currentLocationMarker);
-            currentLocationMarker2.setPosition(location2);
-            currentLocationMarker2.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-            map.getOverlays().add(currentLocationMarker2);
-
-        } else {
-            map.scrollTo(0, 0);
-        }
-
-        //trialFetchManager = new TrialFetchManager(firebaseFirestore, this);
-        //trialFetchManager.fetchTrials("");
     }
 
 
     public void placeTrials(ArrayList<Trial> trials) {
+        GeoPoint location = null;
+        Marker currentLocationMarker = null;
         for (Trial trial: trials) {
-            Marker trialMarker = new Marker(map);
-            //trialMarker.setPosition(trial.getTrialGeolocation());
-            trialMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
-            map.getOverlays().add(trialMarker);
+            location = new GeoPoint(trial.getTrialGeolocation().getLatitude(), trial.getTrialGeolocation().getLongitude());
+            renderLocation(location);
+            currentLocationMarker = new Marker(map);
+            currentLocationMarker.setOnMarkerClickListener((marker, mapView) -> true);
+            currentLocationMarker.setPosition(location);
+            currentLocationMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
+            map.getOverlays().add(currentLocationMarker);
+        }
+        if (currentLocationMarker != null) {
+            map.getController().setCenter(location);
+            map.getController().setZoom(5.0);
+            map.getController().animateTo(location);
         }
     }
 

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/map/MapActivity.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/map/MapActivity.java
@@ -66,6 +66,9 @@ public class MapActivity extends AppCompatActivity implements TrialFetchManager.
         GeoPoint location = null;
         Marker currentLocationMarker = null;
         for (Trial trial: trials) {
+            if (trial.getTrialGeolocation() == null) {
+                continue;
+            }
             location = new GeoPoint(trial.getTrialGeolocation().getLatitude(), trial.getTrialGeolocation().getLongitude());
             renderLocation(location);
             currentLocationMarker = new Marker(map);

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/trial/ExecuteBinomialActivity.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/trial/ExecuteBinomialActivity.java
@@ -2,6 +2,7 @@ package com.faanggang.wisetrack.view.trial;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.location.Location;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -24,9 +25,8 @@ public class ExecuteBinomialActivity extends AppCompatActivity implements View.O
     private int trialResult;
     private static final String TAG = "Snippets";
     private Spinner dropdown;
-    private EditText trialGeolocation;
     ArrayAdapter<String> adapter;
-
+    private Location geolocation;
     private FirebaseAuth mAuth;
     private ExecuteTrialController executeTrialController;
 
@@ -36,10 +36,13 @@ public class ExecuteBinomialActivity extends AppCompatActivity implements View.O
         setContentView(R.layout.activity_execute_binomial);
 
         Bundle extras = getIntent().getExtras();
-
         executeTrialController = new ExecuteTrialController(extras.getString("EXP_ID"));
         mAuth = FirebaseAuth.getInstance();
-
+        if (extras.get("GEOLOCATION") != null) {
+            geolocation = (Location) extras.get("GEOLOCATION");
+        } else {
+            geolocation = null;
+        }
         // get the spinner
         dropdown = findViewById(R.id.spinner_select_trial_result);
         // create string adapter for the spinner and populate it
@@ -83,7 +86,6 @@ public class ExecuteBinomialActivity extends AppCompatActivity implements View.O
         });
 
         // hardcoded address for now; will implement android map fragment later
-        trialGeolocation = findViewById(R.id.trial_geolocation_input);
 
         Button cancelButton = findViewById(R.id.button_cancel);
         Button saveButton = findViewById(R.id.button_save);
@@ -96,8 +98,6 @@ public class ExecuteBinomialActivity extends AppCompatActivity implements View.O
     public void onClick(View v) {
 
         if (v.getId() == R.id.button_save) {
-
-            String geolocation = trialGeolocation.getText().toString();
 
             BinomialTrial currentTrial = new BinomialTrial(trialResult, geolocation, mAuth.getUid(), new Date());
 

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/trial/ExecuteCountActivity.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/trial/ExecuteCountActivity.java
@@ -2,6 +2,7 @@ package com.faanggang.wisetrack.view.trial;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.location.Location;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -21,8 +22,8 @@ import java.util.Map;
 public class ExecuteCountActivity extends AppCompatActivity implements View.OnClickListener {
     private static final String TAG = "Snippets";
     private EditText trialData;
-    private EditText trialGeolocation;
     private TextView oneCount;
+    private Location geolocation;
 
     int trialType;
 
@@ -37,11 +38,15 @@ public class ExecuteCountActivity extends AppCompatActivity implements View.OnCl
         Bundle extras = getIntent().getExtras();
         executeTrialController = new ExecuteTrialController(extras.getString("EXP_ID"));
         mAuth = FirebaseAuth.getInstance();
+        if (extras.get("GEOLOCATION") != null) {
+            geolocation = (Location) extras.get("GEOLOCATION");
+        } else {
+            geolocation = null;
+        }
 
         oneCount = findViewById(R.id.textview_one_count);
         trialData = findViewById(R.id.trial_data_input);
         // hardcoded address for now; will implement android map fragment later
-        trialGeolocation = findViewById(R.id.trial_geolocation_input);
 
         Button cancelButton = findViewById(R.id.button_cancel);
         Button saveButton = findViewById(R.id.button_save);
@@ -64,7 +69,7 @@ public class ExecuteCountActivity extends AppCompatActivity implements View.OnCl
             if (trialType == 2) {
                 count = Integer.parseInt(trialData.getText().toString());
             }
-            String geolocation = trialGeolocation.getText().toString();
+
 
             CountTrial currentTrial = new CountTrial(count, geolocation, mAuth.getUid(), new Date());
 

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/trial/ExecuteMeasurementActivity.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/trial/ExecuteMeasurementActivity.java
@@ -2,6 +2,7 @@ package com.faanggang.wisetrack.view.trial;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.location.Location;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -20,8 +21,7 @@ import java.util.Map;
 public class ExecuteMeasurementActivity extends AppCompatActivity implements View.OnClickListener {
     private static final String TAG = "Snippets";
     private EditText trialData;
-    private EditText trialGeolocation;
-
+    private Location geolocation;
     private FirebaseAuth mAuth;
     private ExecuteTrialController executeTrialController;
 
@@ -31,13 +31,15 @@ public class ExecuteMeasurementActivity extends AppCompatActivity implements Vie
         setContentView(R.layout.activity_execute_measurement);
 
         Bundle extras = getIntent().getExtras();
-
         executeTrialController = new ExecuteTrialController(extras.getString("EXP_ID"));
         mAuth = FirebaseAuth.getInstance();
+        if (extras.get("GEOLOCATION") != null) {
+            geolocation = (Location) extras.get("GEOLOCATION");
+        } else {
+            geolocation = null;
+        }
 
         trialData = findViewById(R.id.trial_data_input);
-        // hardcoded address for now; will implement android map fragment later
-        trialGeolocation = findViewById(R.id.trial_geolocation_input);
 
         Button cancelButton = findViewById(R.id.button_cancel);
         Button saveButton = findViewById(R.id.button_save);
@@ -56,7 +58,6 @@ public class ExecuteMeasurementActivity extends AppCompatActivity implements Vie
                 // measurement field not empty
                 data = Float.parseFloat(trialData.getText().toString());
             }
-            String geolocation = trialGeolocation.getText().toString();
 
             MeasurementTrial currentTrial = new MeasurementTrial(data, geolocation, mAuth.getUid(), new Date());
 

--- a/WiseTrack/app/src/main/res/layout/activity_execute_binomial.xml
+++ b/WiseTrack/app/src/main/res/layout/activity_execute_binomial.xml
@@ -34,17 +34,6 @@
         app:layout_constraintStart_toStartOf="@+id/spinner_select_trial_result"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <EditText
-        android:id="@+id/trial_geolocation_input"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="2dp"
-        android:layout_marginTop="152dp"
-        android:ems="15"
-        android:hint="Enter trial geolocation:"
-        app:layout_constraintStart_toStartOf="@+id/spinner_select_trial_result"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <Button
         android:id="@+id/button_cancel"
         android:layout_width="wrap_content"

--- a/WiseTrack/app/src/main/res/layout/activity_execute_count.xml
+++ b/WiseTrack/app/src/main/res/layout/activity_execute_count.xml
@@ -17,16 +17,6 @@
         app:layout_constraintBottom_toBottomOf="@+id/textview_one_count"
         app:layout_constraintStart_toStartOf="@+id/textview_one_count" />
 
-    <EditText
-        android:id="@+id/trial_geolocation_input"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="26dp"
-        android:layout_marginTop="20dp"
-        android:ems="15"
-        android:hint="Enter trial geolocation:"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textview_one_count" />
 
     <Button
         android:id="@+id/button_cancel"

--- a/WiseTrack/app/src/main/res/layout/activity_execute_measurement.xml
+++ b/WiseTrack/app/src/main/res/layout/activity_execute_measurement.xml
@@ -19,16 +19,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <EditText
-        android:id="@+id/trial_geolocation_input"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="40dp"
-        android:layout_marginTop="20dp"
-        android:ems="15"
-        android:hint="Enter trial geolocation:"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/trial_data_input" />
 
     <Button
         android:id="@+id/button_cancel"


### PR DESCRIPTION
renders trials that have geolocation on them on a map when the option is selected and adds geolocation to trials. 
app crashes if geolocations are strings but that shouldn't be a problem when all of the geolocations are made to be GeoPoints.