### PR TITLE
Fixed a crash issue going from start activity to main menu & added edit user profile intent test

### DIFF
--- a/WiseTrack/app/src/androidTest/java/com/faanggang/wisetrack/EditUserProfileTest.java
+++ b/WiseTrack/app/src/androidTest/java/com/faanggang/wisetrack/EditUserProfileTest.java
@@ -1,0 +1,117 @@
+package com.faanggang.wisetrack;
+
+import android.app.Activity;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.ActivityTestRule;
+
+import com.faanggang.wisetrack.view.MainActivity;
+import com.faanggang.wisetrack.view.MainMenuActivity;
+import com.faanggang.wisetrack.view.user.EditProfileActivity;
+import com.faanggang.wisetrack.view.user.ViewSelfActivity;
+import com.robotium.solo.Solo;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.w3c.dom.Text;
+
+
+/**
+ * Test class for View My Profile and edit profile
+ * This test is to make sure that all edits to user's profile
+ * are successfully saved and shown
+ */
+public class EditUserProfileTest {
+    private Solo solo;
+
+    @Rule
+    public ActivityTestRule<MainActivity> rule =
+            new ActivityTestRule<>(MainActivity.class, true, true);
+
+    @Before
+    public void setUp(){
+        solo = new Solo(InstrumentationRegistry.getInstrumentation(), rule.getActivity());
+    }
+
+    @Test
+    public void start() {
+        Activity activity = rule.getActivity();
+    }
+
+    /**
+     * Check if the correct views are being displayed
+     */
+    @Test
+    public void initializationTest() {
+        solo.clickOnView(solo.getView(R.id.menu_button));
+        //check if current activity is the main menu activity
+        solo.assertCurrentActivity("Wrong activity", MainMenuActivity.class);
+
+        //click on "view my profile" button
+        solo.clickOnView(solo.getView(R.id.menuProfile_Button));
+
+        solo.assertCurrentActivity("Wrong activity", ViewSelfActivity.class);
+
+        //click on "edit profile" button
+        solo.clickOnView(solo.getView(R.id.view_editProfile));
+
+        solo.assertCurrentActivity("Wrong activity", EditProfileActivity.class);
+    }
+
+    /**
+     * check if user information is updated after editing
+     */
+    @Test
+    public void editProfileInfoTest() {
+        solo.clickOnView(solo.getView(R.id.menu_button));
+        solo.assertCurrentActivity("Wrong activity", MainMenuActivity.class);
+        solo.clickOnView(solo.getView(R.id.menuProfile_Button));
+        solo.clickOnView(solo.getView(R.id.view_editProfile));
+
+        solo.clearEditText((EditText) solo.getView(R.id.editTextFirstName));
+        solo.enterText((EditText) solo.getView(R.id.editTextFirstName), "Bob");
+
+        solo.clearEditText((EditText) solo.getView(R.id.editTextLastName));
+        solo.enterText((EditText) solo.getView(R.id.editTextLastName), "Jones");
+
+        solo.clearEditText((EditText) solo.getView(R.id.editTextEmail));
+        solo.enterText((EditText) solo.getView(R.id.editTextEmail), "testemail@email.com");
+
+        solo.clearEditText((EditText) solo.getView(R.id.editTextPhoneNumber));
+        solo.enterText((EditText) solo.getView(R.id.editTextPhoneNumber), "1234567890");
+
+        //click confirm button
+        solo.clickOnView(solo.getView(R.id.confirmEditButton));
+        //check if activity returns to view my profile activity
+        solo.assertCurrentActivity("Wrong activity", ViewSelfActivity.class);
+
+        //check if first name has been updated
+        TextView fNameView = (TextView) solo.getView(R.id.view_fName);
+        String firstName = fNameView.getText().toString();
+        Assert.assertEquals("Bob", firstName);
+        //check if last name has been updated
+        TextView lNameView = (TextView) solo.getView(R.id.view_lastName);
+        String lastName = lNameView.getText().toString();
+        Assert.assertEquals("Jones", lastName);
+        //check if email has been updated
+        TextView emailView = (TextView) solo.getView(R.id.view_Email);
+        String email = emailView.getText().toString();
+        Assert.assertEquals("testemail@email.com", email);
+        //check if phone number has been updated
+        TextView phoneNumView = (TextView) solo.getView(R.id.view_phoneNumber);
+        String phoneNumber = phoneNumView.getText().toString();
+        Assert.assertEquals("1234567890", phoneNumber);
+
+
+    }
+
+    @After
+    public void tearDown() {
+        solo.finishOpenedActivities();
+    }
+}

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/controllers/ConnectionManager.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/controllers/ConnectionManager.java
@@ -30,13 +30,4 @@ public class ConnectionManager {
         }
         return false;
     }
-
-    public boolean isInternetAvailable() {
-        try {
-            String command = "ping -c 1 google.com";
-            return (Runtime.getRuntime().exec(command).waitFor() == 0);
-        } catch (Exception e) {
-            return false;
-        }
-    }
 }

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/model/WiseTrackApplication.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/model/WiseTrackApplication.java
@@ -10,7 +10,6 @@ public class WiseTrackApplication extends Application {
 
     transient private static Users currentUser = null;
     transient private static Experiment currentExperiment = null;
-    transient private static boolean internetConnection;
 
     public static void setCurrentUser(Users user) {
         currentUser = user;
@@ -18,14 +17,5 @@ public class WiseTrackApplication extends Application {
 
     public static Users getCurrentUser() {
         return currentUser;
-    }
-
-
-    public static boolean getWifiConnection() {
-        return internetConnection;
-    }
-
-    public static void setInternetConnection(boolean connection) {
-        internetConnection = connection;
     }
 }

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/MainActivity.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/MainActivity.java
@@ -2,6 +2,7 @@ package com.faanggang.wisetrack.view;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.SystemClock;
 import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
@@ -68,6 +69,7 @@ public class MainActivity extends AppCompatActivity {
             Log.w("EXISTING USERID", currentUser.getUid());
             userManager.storeCurrentUser(currentUser.getUid(), userManager);
             Intent intent = new Intent(this, MainMenuActivity.class);
+            SystemClock.sleep(500);
             startActivity(intent);
         }
     }

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/experiment/ViewExperimentActivity.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/experiment/ViewExperimentActivity.java
@@ -305,6 +305,7 @@ public class ViewExperimentActivity extends AppCompatActivity
         switch (item.getItemId()) {
             case R.id.subscribe_option:
                 subManager.addSubscription(expID, WiseTrackApplication.getCurrentUser().getUserID());
+                Toast.makeText(getApplicationContext(),"You have successfully subscribed to this experiment!", Toast.LENGTH_SHORT).show();
                 return true;  // item clicked return true
             case R.id.unpublish_option:
                 Toast.makeText(this, "Unpublish option selected", Toast.LENGTH_SHORT).show();

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/user/UserNameCreationActivity.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/user/UserNameCreationActivity.java
@@ -54,7 +54,11 @@ public class UserNameCreationActivity extends AppCompatActivity {
                     String username = editUserName.getText().toString();
                     if (detectSpecial(username)) {
                         Toast.makeText(getApplicationContext(), "Username cannot contain special characters", Toast.LENGTH_LONG).show();
-                    } else {
+                    }
+                    else if (username.length() > 20) {
+                        Toast.makeText(getApplicationContext(), "Username cannot contain more than 20 characters", Toast.LENGTH_LONG).show();
+                    }
+                    else {
                         CollectionReference usersRef = db.collection("Users");
                         // query for all user document with the username input by the new user
                         usersRef.whereEqualTo("userName", username)

--- a/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/user/UserNameCreationActivity.java
+++ b/WiseTrack/app/src/main/java/com/faanggang/wisetrack/view/user/UserNameCreationActivity.java
@@ -2,6 +2,7 @@ package com.faanggang.wisetrack.view.user;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.SystemClock;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
@@ -55,8 +56,8 @@ public class UserNameCreationActivity extends AppCompatActivity {
                     if (detectSpecial(username)) {
                         Toast.makeText(getApplicationContext(), "Username cannot contain special characters", Toast.LENGTH_LONG).show();
                     }
-                    else if (username.length() > 20) {
-                        Toast.makeText(getApplicationContext(), "Username cannot contain more than 20 characters", Toast.LENGTH_LONG).show();
+                    else if (username.length() > 13) {
+                        Toast.makeText(getApplicationContext(), "Username cannot contain more than 13 characters", Toast.LENGTH_LONG).show();
                     }
                     else {
                         CollectionReference usersRef = db.collection("Users");
@@ -73,6 +74,7 @@ public class UserNameCreationActivity extends AppCompatActivity {
                                                 userManager.createNewUser(userManager, username);
                                                 Log.d("Username creation", "Username created");
                                                 Intent intent = new Intent(UserNameCreationActivity.this, MainMenuActivity.class);
+                                                SystemClock.sleep(100);
                                                 startActivity(intent);
                                             } else {
                                                 //document exists with the user entered username


### PR DESCRIPTION
Before: app would crash if you press "menu" on Start Activity and immediately pressing one of the button on Main Menu Activity too fast.

Now: Added a 500ms wait from pressing "Menu" button to going to Main Menu Activity, this prevents the crash.